### PR TITLE
Mention the requirement of an API Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ What you need to run this demo:
 * [Git](https://git-scm.com/) & [GitHub Account](https://github.com)
 * [Docker](https://www.docker.com/) with [Docker Compose Plugin](https://docs.docker.com/compose/)
 * Your Favorite IDE or Editor
+* An [OpenAI API Key](https://platform.openai.com/docs/api-reference/create-and-export-an-api-key)
 
 ## Technology
 


### PR DESCRIPTION
As the demo is mainly configured to be utilized with OpenAI GPT and Embeddings, what is later in the Readme explicit mentioned, it should also be mentioned in the Requirements-Section of the Readme. Also this fits that a github account was named as required 😜 

Or not? 