### PR TITLE
Update setup instructions to contain composer scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Checkout the repository, start the docker environment and install dependencies:
 git clone git@github.com:php-llm/symfony-demo.git
 cd symfony-demo
 docker compose up -d
-docker compose run composer install --no-scripts
+docker compose run composer install
 ```
 
 Now you should be able to open https://localhost/ in your browser,


### PR DESCRIPTION
With the first step one should, as a last thing, execute `docker compose run composer install --no-scripts` and then call https://localhost/ and see a chatbot UI. In fact there is an exception with the Symfony App Setup instructions that the assets are not installed and i shoudl execute the import map.

The only thing that happens during composer install that is maybe irritating is a warning to the docker container. 

```
$ docker compose run composer install --no-scripts
The repository at "/app" does not have the correct ownership and git refuses to use it:

fatal: detected dubious ownership in repository at '/app'
To add an exception for this directory, call:

        git config --global --add safe.directory /app
```

But this is not a problem. What is missing is the execution of the script. When i execute `docker compose run composer install` it works and there is no exception. What was your reason to not execute the scripts, that contain the import map stuff?